### PR TITLE
OV-87:  Make Auth Responsive

### DIFF
--- a/frontend/src/bundles/auth/pages/auth.tsx
+++ b/frontend/src/bundles/auth/pages/auth.tsx
@@ -64,7 +64,12 @@ const Auth: React.FC = () => {
             )}
             <Center bgColor="background.600">{getScreen(pathname)}</Center>
             {/* TODO: Add logo */}
-            <Center bgColor="background.900" display={{ base: 'none', sm: 'flex' }}>LOGO</Center>
+            <Center
+                bgColor="background.900"
+                display={{ base: 'none', sm: 'flex' }}
+            >
+                LOGO
+            </Center>
         </SimpleGrid>
     );
 };

--- a/frontend/src/bundles/auth/pages/auth.tsx
+++ b/frontend/src/bundles/auth/pages/auth.tsx
@@ -55,7 +55,7 @@ const Auth: React.FC = () => {
     };
 
     return (
-        <SimpleGrid columns={2} height="100vh">
+        <SimpleGrid columns={{ base: 1, sm: 2 }} height="100vh">
             {/* TODO: Replace with valid loader */}
             {dataStatus === DataStatus.PENDING && (
                 <p style={{ position: 'absolute', top: 0, color: 'white' }}>
@@ -64,7 +64,7 @@ const Auth: React.FC = () => {
             )}
             <Center bgColor="background.600">{getScreen(pathname)}</Center>
             {/* TODO: Add logo */}
-            <Center bgColor="background.900">LOGO</Center>
+            <Center bgColor="background.900" display={{ base: 'none', sm: 'flex' }}>LOGO</Center>
         </SimpleGrid>
     );
 };


### PR DESCRIPTION
This PR is for this task: https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/issues/87
The folowing page sould be responsive in all default breakpints

- [x] Sign-In
- [x] Sign-Up
- [x] Studio

Studio Page already was responsive:
![image](https://github.com/user-attachments/assets/2f00b88d-f247-4e35-aae8-faba13473817)
![image](https://github.com/user-attachments/assets/6e4b0611-fb85-448a-a874-14a9fc4339b6)

Make changes for auth layout
![image](https://github.com/user-attachments/assets/8c560e29-6553-41e4-8a51-efa91dfc72e3)
![image](https://github.com/user-attachments/assets/eb79553b-a036-4c95-8981-acf67ece2922)
![image](https://github.com/user-attachments/assets/34312e8b-85a8-416e-8c74-3b424016104b)
![image](https://github.com/user-attachments/assets/163c6e72-f3d7-4de8-97c1-4450e3e15251)