### PR TITLE
OV-89: Fix fullName validation

### DIFF
--- a/shared/src/bundles/users/validation-schemas/user-sign-up.validation-schema.ts
+++ b/shared/src/bundles/users/validation-schemas/user-sign-up.validation-schema.ts
@@ -48,7 +48,7 @@ const userSignUp = z
     .required()
     .refine((data) => data.fullName.split(/\s+/).length >= 2, {
         message: UserValidationMessage.FULL_NAME_INVALID,
-        path: ['name'],
+        path: ['fullName'],
     })
     .refine((data) => data.password === data.confirmPassword, {
         message: UserValidationMessage.PASS_DONT_MATCH,


### PR DESCRIPTION
Now the validation for fullName is working and the error is displayed under the input field

![image](https://github.com/user-attachments/assets/f59ab439-f980-43d1-bb5c-64686f6f717b)
