### PR TITLE
OV-126:  Update ProtectedRoute to redirect to Sign-In page if no token exists

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -1,19 +1,6 @@
-import { useEffect } from 'react';
-
-import { actions as authActions } from '~/bundles/auth/store/auth.js';
 import { RouterOutlet } from '~/bundles/common/components/components.js';
-import { useAppDispatch } from '~/bundles/common/hooks/hooks.js';
-import { storage, StorageKey } from '~/framework/storage/storage.js';
 
 const App: React.FC = () => {
-    const dispatch = useAppDispatch();
-    useEffect(() => {
-        void storage.get(StorageKey.TOKEN).then((token) => {
-            if (token) {
-                return dispatch(authActions.loadCurrentUser());
-            }
-        });
-    });
     return (
         <>
             <RouterOutlet />

--- a/frontend/src/router/components/protected-route.tsx
+++ b/frontend/src/router/components/protected-route.tsx
@@ -1,16 +1,50 @@
 import { Navigate } from 'react-router-dom';
 
-import { RouterOutlet } from '~/bundles/common/components/components.js';
+import { actions as authActions } from '~/bundles/auth/store/auth.js';
+import {
+    Loader,
+    Overlay,
+    RouterOutlet,
+} from '~/bundles/common/components/components.js';
 import { AppRoute } from '~/bundles/common/enums/app-route.enum.js';
-// import { useAppSelector } from '~/bundles/common/hooks/hooks.js';
+import { DataStatus } from '~/bundles/common/enums/enums.js';
+import {
+    useAppDispatch,
+    useEffect,
+    useState,
+} from '~/bundles/common/hooks/hooks.js';
+import { type ValueOf } from '~/bundles/common/types/types.js';
+import { storage, StorageKey } from '~/framework/storage/storage.js';
 
 const ProtectedRoute: React.FC = () => {
-    // const user = useAppSelector((state) => state.auth.user);
+    const dispatch = useAppDispatch();
 
-    // TODO: for implementing persistence. The following line is temporary
-    const user = true;
+    const [tokenStatus, setTokenStatus] = useState<ValueOf<typeof DataStatus>>(
+        DataStatus.IDLE,
+    );
 
-    if (!user) {
+    useEffect(() => {
+        setTokenStatus(DataStatus.PENDING);
+
+        void storage.get(StorageKey.TOKEN).then((token) => {
+            if (token) {
+                setTokenStatus(DataStatus.FULFILLED);
+                return dispatch(authActions.loadCurrentUser());
+            } else {
+                setTokenStatus(DataStatus.REJECTED);
+            }
+        });
+    }, [dispatch]);
+
+    if (tokenStatus === DataStatus.IDLE || tokenStatus === DataStatus.PENDING) {
+        return (
+            <Overlay isOpen={true}>
+                <Loader />
+            </Overlay>
+        );
+    }
+
+    if (tokenStatus === DataStatus.REJECTED) {
         return <Navigate to={AppRoute.SIGN_IN} replace />;
     }
 


### PR DESCRIPTION
Related issue - https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/issues/126

To decide whether to redirect user to sign-in page token is used instead of user from store.
The reason for that is because if user tries to open home page and token doesn't exist, the request to get current user is not made and auth.dataStatus === 'idle'. If dataStatus is 'idle' it is logical to show loader, but when there is no token dataStatus is always 'idle', so it will be never-ending loader.