### PR TITLE
OV-142: add player controls to studio

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
         "eslint-plugin-react-hooks": "4.6.2",
         "postcss": "8.4.41",
         "vite": "5.4.0",
+        "date-fns": "3.6.0",
         "vite-plugin-pwa": "0.20.1",
         "workbox-core": "7.1.0"
     },
@@ -39,6 +40,7 @@
         "@fortawesome/free-solid-svg-icons": "6.6.0",
         "@fortawesome/react-fontawesome": "0.2.2",
         "@reduxjs/toolkit": "2.2.7",
+        "dnd-timeline": "2.0.0",
         "@remotion/player": "4.0.201",
         "formik": "2.4.6",
         "framer-motion": "11.3.24",

--- a/frontend/src/bundles/common/hooks/hooks.ts
+++ b/frontend/src/bundles/common/hooks/hooks.ts
@@ -2,5 +2,6 @@ export { useAppDispatch } from './use-app-dispatch/use-app-dispatch.hook.js';
 export { useAppForm } from './use-app-form/use-app-form.hook.js';
 export { useAppSelector } from './use-app-selector/use-app-selector.hook.js';
 export { useFormField } from './use-form-field/use-form-field.hook.js';
-export { useCallback, useEffect, useMemo, useState } from 'react';
+export { useCallback, useEffect, useLayoutEffect, useMemo, useRef,useState } from 'react';
 export { useLocation, useNavigate } from 'react-router-dom';
+

--- a/frontend/src/bundles/studio/components/components.ts
+++ b/frontend/src/bundles/studio/components/components.ts
@@ -1,0 +1,3 @@
+export { PlayerControls } from './player-controls/player-controls.js';
+export { Timeline } from './timeline/timeline.js';
+export { VideoMenu } from './video-menu/video-menu.js';

--- a/frontend/src/bundles/studio/components/timeline/item/item.tsx
+++ b/frontend/src/bundles/studio/components/timeline/item/item.tsx
@@ -1,0 +1,40 @@
+import { type Span, useItem } from 'dnd-timeline';
+
+import { Box, Flex } from '~/bundles/common/components/components.js';
+
+type Properties = {
+    id: string;
+    span: Span;
+    children: React.ReactNode;
+};
+
+const Item: React.FC<Properties> = ({ id, span, children }): JSX.Element => {
+    const { setNodeRef, attributes, listeners, itemStyle, itemContentStyle } =
+        useItem({
+            id,
+            span,
+        });
+
+    return (
+        <Box ref={setNodeRef} {...listeners} {...attributes} style={itemStyle}>
+            <Box style={itemContentStyle}>
+                <Flex
+                    width="100%"
+                    overflow="hidden"
+                    margin="2px"
+                    borderRadius="15px"
+                    backgroundColor="lightblue"
+                    color="darkblue"
+                    textAlign="center"
+                    justifyContent="center"
+                    alignItems="center"
+                    height="100%"
+                >
+                    {children}
+                </Flex>
+            </Box>
+        </Box>
+    );
+};
+
+export { Item };

--- a/frontend/src/bundles/studio/components/timeline/row/row.tsx
+++ b/frontend/src/bundles/studio/components/timeline/row/row.tsx
@@ -1,0 +1,27 @@
+import { type RowDefinition, useRow } from 'dnd-timeline';
+
+import { Box } from '~/bundles/common/components/components.js';
+
+type Properties = RowDefinition & {
+    children: React.ReactNode;
+};
+
+const Row: React.FC<Properties> = ({
+    id,
+    children,
+}: Properties): JSX.Element => {
+    const { setNodeRef, rowWrapperStyle, rowStyle } = useRow({ id });
+
+    return (
+        <Box style={{ ...rowWrapperStyle, minHeight: 50 }}>
+            <Box
+                ref={setNodeRef}
+                style={{ ...rowStyle, border: '1px solid white' }}
+            >
+                {children}
+            </Box>
+        </Box>
+    );
+};
+
+export { Row };

--- a/frontend/src/bundles/studio/components/timeline/subrow/subrow.tsx
+++ b/frontend/src/bundles/studio/components/timeline/subrow/subrow.tsx
@@ -1,0 +1,17 @@
+import { Box } from '~/bundles/common/components/components.js';
+
+type Properties = {
+    children: React.ReactNode;
+};
+
+const Subrow: React.FC<Properties> = ({
+    children,
+}: Properties): JSX.Element => {
+    return (
+        <Box height="50px" position="relative">
+            {children}
+        </Box>
+    );
+};
+
+export { Subrow };

--- a/frontend/src/bundles/studio/components/timeline/timeaxis/timeaxis.tsx
+++ b/frontend/src/bundles/studio/components/timeline/timeaxis/timeaxis.tsx
@@ -1,0 +1,107 @@
+import { useTimelineContext } from 'dnd-timeline';
+
+import { Box } from '~/bundles/common/components/components.js';
+import { useMemo } from '~/bundles/common/hooks/hooks.js';
+import {
+    type Marker,
+    type MarkerDefinition,
+} from '~/bundles/studio/helpers/time-axis-markers.js';
+
+type Properties = {
+    markers: MarkerDefinition[];
+};
+
+const TimeAxis: React.FC<Properties> = ({
+    markers,
+}: Properties): JSX.Element => {
+    const { range, direction, sidebarWidth, valueToPixels } =
+        useTimelineContext();
+    const side = direction === 'rtl' ? 'right' : 'left';
+
+    const computedMarkers = useMemo(() => {
+        const sortedMarkers = markers.toSorted((a, b) => b.value - a.value);
+        const delta = sortedMarkers.at(-1)?.value ?? 0;
+        const rangeSize = range.end - range.start;
+        const startTime = Math.floor(range.start / delta) * delta;
+        const endTime = range.end;
+        const timezoneOffset = new Date().getTimezoneOffset() * 60 * 1000;
+        const markerSideDeltas: Marker[] = [];
+
+        for (let time = startTime; time <= endTime; time += delta) {
+            const multiplierIndex = sortedMarkers.findIndex((marker) => {
+                const timeOffset = (time - timezoneOffset) % marker.value === 0;
+                const isWithinMaxRange =
+                    !marker.maxRangeSize || rangeSize <= marker.maxRangeSize;
+                const isWithinMinRange =
+                    !marker.minRangeSize || rangeSize >= marker.minRangeSize;
+
+                return timeOffset && isWithinMaxRange && isWithinMinRange;
+            });
+
+            if (multiplierIndex === -1) {
+                continue;
+            }
+
+            const multiplier = sortedMarkers[multiplierIndex];
+            const label = multiplier?.getLabel?.(new Date(time));
+
+            if (label) {
+                markerSideDeltas.push({
+                    label,
+                    heightMultiplier: 1 / (multiplierIndex + 1),
+                    sideDelta: valueToPixels(time - range.start),
+                });
+            }
+        }
+
+        return markerSideDeltas;
+    }, [range, valueToPixels, markers]);
+
+    return (
+        <Box
+            style={{
+                height: '20px',
+                position: 'relative',
+                overflow: 'hidden',
+                [side === 'right' ? 'marginRight' : 'marginLeft']:
+                    `${sidebarWidth}px`,
+            }}
+        >
+            {computedMarkers.map((marker, index) => (
+                <Box
+                    key={`${marker.sideDelta}-${index}`}
+                    style={{
+                        position: 'absolute',
+                        bottom: 0,
+                        display: 'flex',
+                        flexDirection: 'row',
+                        justifyContent: 'flex-start',
+                        alignItems: 'flex-end',
+                        height: '100%',
+                        [side]: `${marker.sideDelta}px`,
+                    }}
+                >
+                    <Box
+                        style={{
+                            width: '1px',
+                            height: `${100 * marker.heightMultiplier}%`,
+                        }}
+                    />
+                    {marker.label && (
+                        <Box
+                            style={{
+                                paddingLeft: '3px',
+                                alignSelf: 'flex-start',
+                                fontWeight: marker.heightMultiplier * 1000,
+                            }}
+                        >
+                            {marker.label}
+                        </Box>
+                    )}
+                </Box>
+            ))}
+        </Box>
+    );
+};
+
+export { TimeAxis };

--- a/frontend/src/bundles/studio/components/timeline/timeline-view/timeline-view.tsx
+++ b/frontend/src/bundles/studio/components/timeline/timeline-view/timeline-view.tsx
@@ -1,0 +1,58 @@
+import {
+    type ItemDefinition,
+    type RowDefinition,
+    groupItemsToSubrows,
+    useTimelineContext,
+} from 'dnd-timeline';
+
+import { useMemo } from '~/bundles/common/hooks/hooks.js';
+import { timeAxisMarkers } from '~/bundles/studio/helpers/time-axis-markers.js';
+
+import { Item } from '../item/item.js';
+import { Row } from '../row/row.js';
+import { Subrow } from '../subrow/subrow.js';
+import { TimeAxis } from '../timeaxis/timeaxis.js';
+import { TimeCursor } from '../timecursor/timecursor.js';
+
+interface TimelineProperties {
+    rows: RowDefinition[];
+    items: ItemDefinition[];
+}
+
+const TimelineView: React.FC<TimelineProperties> = ({
+    rows,
+    items,
+}): JSX.Element => {
+    const { setTimelineRef, style, range } = useTimelineContext();
+
+    const groupedSubrows = useMemo(
+        () => groupItemsToSubrows(items, range),
+        [items, range],
+    );
+    return (
+        <div ref={setTimelineRef} style={style}>
+            <TimeAxis markers={timeAxisMarkers} />
+            <TimeCursor />
+
+            {rows.map((row) => (
+                <Row id={row.id} key={row.id}>
+                    {groupedSubrows[row.id]?.map((subrow, index) => (
+                        <Subrow key={`${row.id}-${index}`}>
+                            {subrow.map((item) => (
+                                <Item
+                                    id={item.id}
+                                    key={item.id}
+                                    span={item.span}
+                                >
+                                    {`Item ${item.id}`}
+                                </Item>
+                            ))}
+                        </Subrow>
+                    ))}
+                </Row>
+            ))}
+        </div>
+    );
+};
+
+export { TimelineView };

--- a/frontend/src/bundles/studio/components/timeline/timeline.tsx
+++ b/frontend/src/bundles/studio/components/timeline/timeline.tsx
@@ -1,0 +1,84 @@
+import {
+    type DragEndEvent,
+    type ItemDefinition,
+    type Range,
+    type ResizeEndEvent,
+    type RowDefinition,
+    TimelineContext,
+} from 'dnd-timeline';
+
+import { useCallback, useState } from '~/bundles/common/hooks/hooks.js';
+
+import { TimelineView } from './timeline-view/timeline-view.js';
+
+type Properties = {
+    initialRange: Range;
+    initialRows: RowDefinition[];
+    initialItems: ItemDefinition[];
+};
+
+const Timeline: React.FC<Properties> = ({
+    initialRange,
+    initialRows,
+    initialItems,
+}): JSX.Element => {
+    const [range, setRange] = useState(initialRange);
+    const [items, setItems] = useState(initialItems);
+    const rows = initialRows;
+    const onResizeEnd = useCallback((event: ResizeEndEvent) => {
+        const updatedSpan =
+            event.active.data.current.getSpanFromResizeEvent?.(event);
+
+        if (!updatedSpan) {
+            return;
+        }
+
+        const activeItemId = event.active.id;
+
+        setItems((previous) =>
+            previous.map((item) => {
+                return item.id === activeItemId
+                    ? { ...item, span: updatedSpan }
+                    : item;
+            }),
+        );
+    }, []);
+    const onDragEnd = useCallback((event: DragEndEvent) => {
+        const activeRowId = event.over?.id as string;
+        const updatedSpan =
+            event.active.data.current.getSpanFromDragEvent?.(event);
+
+        if (!updatedSpan || !activeRowId) {
+            return;
+        }
+
+        const activeItemId = event.active.id;
+
+        setItems((previous) =>
+            previous.map((item) => {
+                if (item.id !== activeItemId) {
+                    return item;
+                }
+
+                return {
+                    ...item,
+                    rowId: activeRowId,
+                    span: updatedSpan,
+                };
+            }),
+        );
+    }, []);
+
+    return (
+        <TimelineContext
+            range={range}
+            onDragEnd={onDragEnd}
+            onResizeEnd={onResizeEnd}
+            onRangeChanged={setRange}
+        >
+            <TimelineView items={items} rows={rows} />
+        </TimelineContext>
+    );
+};
+
+export { Timeline };

--- a/frontend/src/bundles/studio/helpers/time-axis-markers.ts
+++ b/frontend/src/bundles/studio/helpers/time-axis-markers.ts
@@ -1,0 +1,75 @@
+import {
+    format,
+    hoursToMilliseconds,
+    minutesToMilliseconds,
+    secondsToMilliseconds,
+} from 'date-fns';
+
+type Marker = {
+    label?: string;
+    sideDelta: number;
+    heightMultiplier: number;
+};
+
+type MarkerDefinition = {
+    value: number;
+    maxRangeSize?: number;
+    minRangeSize?: number;
+    getLabel?: (time: Date) => string;
+};
+
+const timeAxisMarkers: MarkerDefinition[] = [
+    {
+        value: hoursToMilliseconds(24),
+    },
+    {
+        value: hoursToMilliseconds(2),
+        minRangeSize: hoursToMilliseconds(24),
+    },
+    {
+        value: hoursToMilliseconds(1),
+        minRangeSize: hoursToMilliseconds(24),
+    },
+    {
+        value: hoursToMilliseconds(1),
+        maxRangeSize: hoursToMilliseconds(24),
+        getLabel: (date: Date) => format(date, 'k'),
+    },
+    {
+        value: minutesToMilliseconds(30),
+        maxRangeSize: hoursToMilliseconds(24),
+        minRangeSize: hoursToMilliseconds(12),
+        getLabel: (date: Date) => format(date, 'hh:mm'),
+    },
+    {
+        value: minutesToMilliseconds(15),
+        maxRangeSize: hoursToMilliseconds(12),
+        getLabel: (date: Date) => format(date, 'hh:mm'),
+    },
+    {
+        value: minutesToMilliseconds(5),
+        maxRangeSize: hoursToMilliseconds(6),
+        minRangeSize: hoursToMilliseconds(3),
+        getLabel: (date: Date) => format(date, 'hh:mm'),
+    },
+    {
+        value: minutesToMilliseconds(5),
+        maxRangeSize: hoursToMilliseconds(3),
+        minRangeSize: hoursToMilliseconds(1),
+        getLabel: (date: Date) => format(date, 'HH:mm'),
+    },
+    {
+        value: secondsToMilliseconds(30),
+        maxRangeSize: minutesToMilliseconds(30),
+        minRangeSize: minutesToMilliseconds(10),
+        getLabel: (date: Date) => format(date, 'mm:ss'),
+    },
+    {
+        value: 1000,
+        maxRangeSize: minutesToMilliseconds(10),
+        minRangeSize: minutesToMilliseconds(1),
+        getLabel: (date: Date) => format(date, 's'),
+    },
+];
+
+export { type Marker, type MarkerDefinition, timeAxisMarkers };

--- a/frontend/src/bundles/studio/mocks/mock.helper.ts
+++ b/frontend/src/bundles/studio/mocks/mock.helper.ts
@@ -1,0 +1,74 @@
+import { minutesToMilliseconds } from 'date-fns';
+import {
+    type ItemDefinition,
+    type Range,
+    type RowDefinition,
+    type Span,
+} from 'dnd-timeline';
+
+const generateMockRows = (count: number): RowDefinition[] => {
+    return Array.from({ length: count })
+        .fill(0)
+        .map((_, index): RowDefinition => {
+            const disabled = false;
+
+            let id = `${index + 1}`;
+            if (disabled) {
+                id += ' (disabled)';
+            }
+
+            return {
+                id,
+                disabled,
+            };
+        });
+};
+
+const getRandomInRange = (min: number, max: number): number => {
+    return Math.random() * (max - min) + min;
+};
+
+const DEFAULT_MIN_DURATION = minutesToMilliseconds(1);
+const DEFAULT_MAX_DURATION = minutesToMilliseconds(3);
+
+const generateRandomSpan = (
+    range: Range,
+    minDuration: number = DEFAULT_MIN_DURATION,
+    maxDuration: number = DEFAULT_MAX_DURATION,
+): Span => {
+    const duration = getRandomInRange(minDuration, maxDuration);
+
+    const start = getRandomInRange(range.start, range.end - duration);
+
+    const end = start + duration;
+
+    return {
+        start: start,
+        end: end,
+    };
+};
+
+const generateMockItems = (
+    count: number,
+    range: Range,
+    rows: RowDefinition[],
+): ItemDefinition[] => {
+    const items = Array.from({ length: count }).fill(0);
+
+    return items.map((_, index): ItemDefinition => {
+        const row = rows[Math.floor(Math.random() * rows.length)];
+        const rowId = row?.id;
+
+        const span = generateRandomSpan(range);
+
+        const id = `${index + 1}`;
+
+        return {
+            id,
+            rowId: rowId ?? '',
+            span,
+        };
+    });
+};
+
+export { generateMockItems, generateMockRows, generateRandomSpan };

--- a/frontend/src/bundles/studio/pages/studio.tsx
+++ b/frontend/src/bundles/studio/pages/studio.tsx
@@ -19,17 +19,20 @@ import {
     generateMockRows,
 } from '~/bundles/studio/mocks/mock.helper.js';
 
-import { Timeline } from '../components/timeline/timeline.js';
-import { VideoMenu } from '../components/video-menu/video-menu.js';
+import {
+    PlayerControls,
+    Timeline,
+    VideoMenu,
+} from '../components/components.js';
 
 const timezoneOffset = minutesToMilliseconds(new Date().getTimezoneOffset());
 const initialRange: Range = {
     start: timezoneOffset,
     end: minutesToMilliseconds(45) + timezoneOffset,
 };
-const initialRows: RowDefinition[] = generateMockRows(15);
+const initialRows: RowDefinition[] = generateMockRows(2);
 const initialItems: ItemDefinition[] = generateMockItems(
-    10,
+    5,
     initialRange,
     initialRows,
 );
@@ -60,10 +63,10 @@ const Studio: React.FC = () => {
                     left: '0',
                     bottom: '0',
                     width: '100%',
-                    height: '180px',
                     alignItems: 'stretch',
                 }}
             >
+                <PlayerControls />
                 <Box>
                     <Timeline
                         initialRange={initialRange}

--- a/frontend/src/bundles/studio/pages/studio.tsx
+++ b/frontend/src/bundles/studio/pages/studio.tsx
@@ -1,12 +1,38 @@
+import { minutesToMilliseconds } from 'date-fns';
 import {
+    type ItemDefinition,
+    type Range,
+    type RowDefinition,
+} from 'dnd-timeline';
+
+import {
+    Box,
     Button,
     Header,
     Icon,
     IconButton,
+    VStack,
 } from '~/bundles/common/components/components.js';
 import { IconName } from '~/bundles/common/icons/icons.js';
+import {
+    generateMockItems,
+    generateMockRows,
+} from '~/bundles/studio/mocks/mock.helper.js';
 
+import { Timeline } from '../components/timeline/timeline.js';
 import { VideoMenu } from '../components/video-menu/video-menu.js';
+
+const timezoneOffset = minutesToMilliseconds(new Date().getTimezoneOffset());
+const initialRange: Range = {
+    start: timezoneOffset,
+    end: minutesToMilliseconds(45) + timezoneOffset,
+};
+const initialRows: RowDefinition[] = generateMockRows(15);
+const initialItems: ItemDefinition[] = generateMockItems(
+    10,
+    initialRange,
+    initialRows,
+);
 
 const Studio: React.FC = () => {
     return (
@@ -28,6 +54,24 @@ const Studio: React.FC = () => {
                 }
             />
             <VideoMenu />
+            <VStack
+                sx={{
+                    position: 'fixed',
+                    left: '0',
+                    bottom: '0',
+                    width: '100%',
+                    height: '180px',
+                    alignItems: 'stretch',
+                }}
+            >
+                <Box>
+                    <Timeline
+                        initialRange={initialRange}
+                        initialItems={initialItems}
+                        initialRows={initialRows}
+                    />
+                </Box>
+            </VStack>
         </>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
                 "@fortawesome/react-fontawesome": "0.2.2",
                 "@reduxjs/toolkit": "2.2.7",
                 "@remotion/player": "4.0.201",
+                "dnd-timeline": "2.0.0",
                 "formik": "2.4.6",
                 "framer-motion": "11.3.24",
                 "react": "18.3.1",
@@ -104,6 +105,7 @@
                 "@vite-pwa/assets-generator": "0.2.4",
                 "@vitejs/plugin-react": "4.3.1",
                 "autoprefixer": "10.4.20",
+                "date-fns": "3.6.0",
                 "eslint-plugin-jsx-a11y": "6.9.0",
                 "eslint-plugin-react": "7.35.0",
                 "eslint-plugin-react-hooks": "4.6.2",
@@ -4395,6 +4397,42 @@
             },
             "peerDependencies": {
                 "postcss-selector-parser": "^6.0.13"
+            }
+        },
+        "node_modules/@dnd-kit/accessibility": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+            "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/core": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+            "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+            "dependencies": {
+                "@dnd-kit/accessibility": "^3.1.0",
+                "@dnd-kit/utilities": "^3.2.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@dnd-kit/utilities": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+            "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
             }
         },
         "node_modules/@dual-bundle/import-meta-resolve": {
@@ -9005,6 +9043,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/date-fns": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+            "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
+            }
+        },
         "node_modules/dateformat": {
             "version": "4.6.3",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -9230,6 +9278,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dnd-timeline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dnd-timeline/-/dnd-timeline-2.0.0.tgz",
+            "integrity": "sha512-D4F2tugJDLI+aQO0U9uFUu4FPiS9SJj+o/KoWZLTcg0U5/YULjfg85TaGBbgiOv3prEdcza46NDAeIBWaM3CZQ==",
+            "dependencies": {
+                "@dnd-kit/core": "^6.1.0",
+                "@dnd-kit/utilities": "^3.2.2",
+                "resize-observer-polyfill": "^1.5.1"
             }
         },
         "node_modules/doctrine": {
@@ -15186,6 +15244,11 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
             "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
+        },
+        "node_modules/resize-observer-polyfill": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+            "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         },
         "node_modules/resolve": {
             "version": "1.22.8",


### PR DESCRIPTION
Also depends on [OV-110](https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/pull/137)

Added player controls component to studio page.

I found an issue with the timeline component: if there is not enough space for generated items, more rows are automatically created, and the timeline component becomes bigger. @stefano-lacorazza is working on that.

![image](https://github.com/user-attachments/assets/bdc7b9c6-309f-4183-9f1a-0d662b6b9617)
