### PR TITLE
OV-141:  Update HttpMethods to use enum insted of plain string

### DIFF
--- a/backend/src/bundles/users/user.controller.ts
+++ b/backend/src/bundles/users/user.controller.ts
@@ -42,7 +42,7 @@ class UserController extends BaseController {
 
         this.addRoute({
             path: UsersApiPath.CURRENT,
-            method: 'GET',
+            method: HTTPMethod.GET,
             handler: (handlerOptions: ApiHandlerOptions) =>
                 this.getCurrent(handlerOptions),
         });

--- a/backend/src/common/constants/white-routes.constants.ts
+++ b/backend/src/common/constants/white-routes.constants.ts
@@ -13,7 +13,7 @@ const WHITE_ROUTES = [
     },
     {
         path: /\/v1\/documentation\/.*/,
-        method: 'GET',
+        method: HTTPMethod.GET,
     },
 ];
 


### PR DESCRIPTION
This pull request is to replace those plain string for enums values for the HttpMethods https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/issues/141