### PR TITLE
OV-194: Fix styling studio page

### DIFF
--- a/frontend/src/bundles/common/components/player/player.tsx
+++ b/frontend/src/bundles/common/components/player/player.tsx
@@ -50,12 +50,11 @@ const Player = ({
                 compositionWidth={size.width}
                 compositionHeight={size.height}
                 fps={30}
-                style={{
-                    maxHeight: '100%',
-                    ...(orientation === VideoPreview.LANDSCAPE
+                style={
+                    orientation === VideoPreview.LANDSCAPE
                         ? LandscapeStyle
-                        : PortraitStyle),
-                }}
+                        : PortraitStyle
+                }
             />
         </Flex>
     );

--- a/frontend/src/bundles/common/components/player/player.tsx
+++ b/frontend/src/bundles/common/components/player/player.tsx
@@ -50,11 +50,12 @@ const Player = ({
                 compositionWidth={size.width}
                 compositionHeight={size.height}
                 fps={30}
-                style={
-                    orientation === VideoPreview.LANDSCAPE
+                style={{
+                    maxHeight: '100%',
+                    ...(orientation === VideoPreview.LANDSCAPE
                         ? LandscapeStyle
-                        : PortraitStyle
-                }
+                        : PortraitStyle),
+                }}
             />
         </Flex>
     );

--- a/frontend/src/bundles/common/components/player/styles/landscape.style.ts
+++ b/frontend/src/bundles/common/components/player/styles/landscape.style.ts
@@ -2,6 +2,7 @@ const LandscapeStyle = {
     width: '40%',
     minWidth: '400px',
     objectFit: 'contain',
+    maxHeight: '100%',
 } as const;
 
 export { LandscapeStyle };

--- a/frontend/src/bundles/common/components/player/styles/portrait.style.ts
+++ b/frontend/src/bundles/common/components/player/styles/portrait.style.ts
@@ -2,6 +2,7 @@ const PortraitStyle = {
     width: '10%',
     minWidth: '200px',
     objectFit: 'contain',
+    maxHeight: '100%',
 } as const;
 
 export { PortraitStyle };

--- a/frontend/src/bundles/studio/components/video-menu/components/menu/menu.tsx
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu/menu.tsx
@@ -45,7 +45,7 @@ const Menu: React.FC<Properties> = ({
                 color: 'white',
                 borderTopRightRadius: 'xl',
                 borderBottomRightRadius: 'xl',
-                zIndex: 1000,
+                zIndex: 100,
             }}
         >
             <VStack spacing={1} align="stretch" p={2} w="100%">

--- a/frontend/src/bundles/studio/components/video-menu/components/menu/menu.tsx
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu/menu.tsx
@@ -45,6 +45,7 @@ const Menu: React.FC<Properties> = ({
                 color: 'white',
                 borderTopRightRadius: 'xl',
                 borderBottomRightRadius: 'xl',
+                zIndex: 1000,
             }}
         >
             <VStack spacing={1} align="stretch" p={2} w="100%">

--- a/frontend/src/bundles/studio/pages/studio.tsx
+++ b/frontend/src/bundles/studio/pages/studio.tsx
@@ -26,7 +26,6 @@ import {
 } from '../components/components.js';
 import { mockItems } from '../mocks/mock.helper.js';
 import { actions as studioActionCreator } from '../store/studio.js';
-import styles from './styles.module.css';
 
 const initialRange: Range = {
     start: minutesToMilliseconds(0),
@@ -42,7 +41,13 @@ const Studio: React.FC = () => {
     }, [dispatch]);
 
     return (
-        <Box minHeight="100vh" height="100%" position="relative">
+        <Box
+            minHeight="100vh"
+            height="100%"
+            position="relative"
+            display="flex"
+            flexDirection="column"
+        >
             <Header
                 center={
                     <Button
@@ -62,7 +67,15 @@ const Studio: React.FC = () => {
             />
 
             <VideoMenu />
-            <VStack className={styles['timeline']} alignItems={'stretch'}>
+            <Box flex="1 1 auto">
+                <Player
+                    VideoComponent={VideoComponent}
+                    playerRef={playerReference}
+                    durationInFrames={300}
+                />
+            </Box>
+
+            <VStack alignItems={'stretch'}>
                 <PlayerControls />
                 <Box>
                     <Timeline
@@ -71,12 +84,6 @@ const Studio: React.FC = () => {
                     />
                 </Box>
             </VStack>
-
-            <Player
-                VideoComponent={VideoComponent}
-                playerRef={playerReference}
-                durationInFrames={300}
-            />
         </Box>
     );
 };

--- a/frontend/src/bundles/studio/pages/styles.module.css
+++ b/frontend/src/bundles/studio/pages/styles.module.css
@@ -1,6 +1,0 @@
-.timeline {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-}

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -23,7 +23,7 @@ const routes = [
                 path: AppRoute.ROOT,
                 element: (
                     <ProtectedRoute>
-                        <Home />,
+                        <Home />
                     </ProtectedRoute>
                 ),
             },
@@ -31,7 +31,7 @@ const routes = [
                 path: AppRoute.STUDIO,
                 element: (
                     <ProtectedRoute>
-                        <Studio />,
+                        <Studio />
                     </ProtectedRoute>
                 ),
             },
@@ -39,7 +39,7 @@ const routes = [
                 path: AppRoute.MY_AVATAR,
                 element: (
                     <ProtectedRoute>
-                        <MyAvatar />,
+                        <MyAvatar />
                     </ProtectedRoute>
                 ),
             },


### PR DESCRIPTION
- Fixed menu
- Made the player responsive when the page starts shrinking
- Fixed empty space at the bottom of all pages

Styles approach will be fixed in this pr: [OV-164](https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/pull/178)

Menu before:
![image](https://github.com/user-attachments/assets/d9982e9d-421d-4f22-9e28-ab12ec4cfda9)

Menu after:
![image](https://github.com/user-attachments/assets/b49faaa7-3e1b-4da0-ad1b-d5a5ef10cdff)

Player before:
https://github.com/user-attachments/assets/877bda91-fdb1-4a2b-bb8f-3e81cc88629c

Player after:
https://github.com/user-attachments/assets/714386e3-27a9-4637-b133-138032a0e8cb
https://github.com/user-attachments/assets/089df538-df95-4a18-994a-22e86d25225d

Empty space at the bottom of the pages:
![image](https://github.com/user-attachments/assets/2ca4c876-9613-4e2a-9ed3-40b953f634d7)
![image](https://github.com/user-attachments/assets/0fc245d8-ebd4-447c-a93a-8358c723bbbe)

Fixed empty space:
![image](https://github.com/user-attachments/assets/4faf5a3b-6d0e-49dc-a519-7e9aefdb62a6)


