### PR TITLE
OV-202: Add play button to scripts

### DIFF
--- a/frontend/src/bundles/common/components/components.ts
+++ b/frontend/src/bundles/common/components/components.ts
@@ -40,6 +40,7 @@ export {
     SliderThumb,
     SliderTrack,
     Spacer,
+    Spinner,
     Stack,
     Tab,
     Text,
@@ -47,7 +48,9 @@ export {
     VStack,
 } from '@chakra-ui/react';
 export { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+export { Player as LibraryPlayer } from '@remotion/player';
 export { FormikProvider as FormProvider } from 'formik';
 export { Fragment } from 'react';
 export { Provider as StoreProvider } from 'react-redux';
 export { Navigate, Outlet as RouterOutlet } from 'react-router-dom';
+export { Audio } from 'remotion';

--- a/frontend/src/bundles/common/icons/helper/icon-conversion.helper.ts
+++ b/frontend/src/bundles/common/icons/helper/icon-conversion.helper.ts
@@ -8,6 +8,7 @@ import {
     faPause,
     faPlay,
     faRightFromBracket,
+    faStop,
     faVolumeHigh,
     faVolumeOff,
 } from '@fortawesome/free-solid-svg-icons';
@@ -22,6 +23,7 @@ const forwardStepIcon = iconConverter(faForwardStep);
 const pauseIcon = iconConverter(faPause);
 const playIcon = iconConverter(faPlay);
 const fileLinesIcon = iconConverter(faFileLines);
+const StopIcon = iconConverter(faStop);
 
 const CloudArrowDownIcon = iconConverter(faCloudArrowDown);
 const VolumeHighIcon = iconConverter(faVolumeHigh);
@@ -39,6 +41,7 @@ export {
     pauseIcon,
     playIcon,
     RightFromBracketIcon,
+    StopIcon,
     VolumeHighIcon,
     VolumeOffIcon,
 };

--- a/frontend/src/bundles/common/icons/helper/icon-conversion.helper.ts
+++ b/frontend/src/bundles/common/icons/helper/icon-conversion.helper.ts
@@ -23,7 +23,7 @@ const forwardStepIcon = iconConverter(faForwardStep);
 const pauseIcon = iconConverter(faPause);
 const playIcon = iconConverter(faPlay);
 const fileLinesIcon = iconConverter(faFileLines);
-const StopIcon = iconConverter(faStop);
+const Stop = iconConverter(faStop);
 
 const CloudArrowDownIcon = iconConverter(faCloudArrowDown);
 const VolumeHighIcon = iconConverter(faVolumeHigh);
@@ -41,7 +41,7 @@ export {
     pauseIcon,
     playIcon,
     RightFromBracketIcon,
-    StopIcon,
+    Stop,
     VolumeHighIcon,
     VolumeOffIcon,
 };

--- a/frontend/src/bundles/common/icons/icon-name.ts
+++ b/frontend/src/bundles/common/icons/icon-name.ts
@@ -27,6 +27,7 @@ import {
     pauseIcon,
     playIcon,
     RightFromBracketIcon,
+    StopIcon,
     VolumeHighIcon,
     VolumeOffIcon,
 } from './helper/icon-conversion.helper.js';
@@ -42,6 +43,7 @@ const IconName = {
     PLAY_STEP_BACK: backwardStepIcon,
     PLAY_STEP_NEXT: forwardStepIcon,
     PAUSE: pauseIcon,
+    STOP: StopIcon,
     SCROLL: faScroll,
     VOLUME: VolumeHighIcon,
     VOLUME_OFF: VolumeOffIcon,

--- a/frontend/src/bundles/common/icons/icon-name.ts
+++ b/frontend/src/bundles/common/icons/icon-name.ts
@@ -27,7 +27,7 @@ import {
     pauseIcon,
     playIcon,
     RightFromBracketIcon,
-    StopIcon,
+    Stop,
     VolumeHighIcon,
     VolumeOffIcon,
 } from './helper/icon-conversion.helper.js';
@@ -43,7 +43,7 @@ const IconName = {
     PLAY_STEP_BACK: backwardStepIcon,
     PLAY_STEP_NEXT: forwardStepIcon,
     PAUSE: pauseIcon,
-    STOP: StopIcon,
+    STOP: Stop,
     SCROLL: faScroll,
     VOLUME: VolumeHighIcon,
     VOLUME_OFF: VolumeOffIcon,

--- a/frontend/src/bundles/studio/components/audio-player/audio-player.tsx
+++ b/frontend/src/bundles/studio/components/audio-player/audio-player.tsx
@@ -14,12 +14,14 @@ type Properties = {
     isPlaying: boolean;
     audioUrl: string;
     handleAudioEnd: () => void;
+    handleSetDuration: (duration: number) => void;
 };
 
 const AudioPlayer: React.FC<Properties> = ({
     isPlaying,
     audioUrl,
     handleAudioEnd,
+    handleSetDuration,
 }) => {
     const playerReference = useRef<PlayerRef>(null);
 
@@ -37,11 +39,12 @@ const AudioPlayer: React.FC<Properties> = ({
         getAudioData(audioUrl)
             .then(({ durationInSeconds }) => {
                 setDurationInFrames(Math.round(durationInSeconds * FPS));
+                handleSetDuration(durationInSeconds);
             })
             .catch(() => {
                 setDurationInFrames(1);
             });
-    }, [audioUrl]);
+    }, [audioUrl, handleSetDuration]);
 
     useEffect(() => {
         const player = playerReference.current;

--- a/frontend/src/bundles/studio/components/audio-player/audio-player.tsx
+++ b/frontend/src/bundles/studio/components/audio-player/audio-player.tsx
@@ -1,0 +1,70 @@
+import { getAudioData } from '@remotion/media-utils';
+import { type PlayerRef } from '@remotion/player';
+
+import {
+    Audio,
+    LibraryPlayer,
+} from '~/bundles/common/components/components.js';
+import { useEffect, useRef, useState } from '~/bundles/common/hooks/hooks.js';
+
+import { FPS } from './constants/constants.js';
+import { AudioEvent } from './enums/enums.js';
+
+type Properties = {
+    isPlaying: boolean;
+    audioUrl: string;
+    handleAudioEnd: () => void;
+};
+
+const AudioPlayer: React.FC<Properties> = ({
+    isPlaying,
+    audioUrl,
+    handleAudioEnd,
+}) => {
+    const playerReference = useRef<PlayerRef>(null);
+
+    const [durationInFrames, setDurationInFrames] = useState(1);
+
+    useEffect(() => {
+        if (isPlaying) {
+            playerReference.current?.play();
+        } else {
+            playerReference.current?.pauseAndReturnToPlayStart();
+        }
+    }, [isPlaying]);
+
+    useEffect(() => {
+        getAudioData(audioUrl)
+            .then(({ durationInSeconds }) => {
+                setDurationInFrames(Math.round(durationInSeconds * FPS));
+            })
+            .catch(() => {
+                setDurationInFrames(1);
+            });
+    }, [audioUrl]);
+
+    useEffect(() => {
+        const player = playerReference.current;
+
+        player?.addEventListener(AudioEvent.ENDED, handleAudioEnd);
+
+        return () => {
+            player?.removeEventListener(AudioEvent.ENDED, handleAudioEnd);
+        };
+    }, [handleAudioEnd, playerReference]);
+
+    return (
+        <LibraryPlayer
+            ref={playerReference}
+            component={Audio}
+            inputProps={{ src: audioUrl }}
+            fps={FPS}
+            durationInFrames={durationInFrames}
+            compositionWidth={1}
+            compositionHeight={1}
+            style={{ position: 'absolute' }}
+        />
+    );
+};
+
+export { AudioPlayer };

--- a/frontend/src/bundles/studio/components/audio-player/constants/constants.ts
+++ b/frontend/src/bundles/studio/components/audio-player/constants/constants.ts
@@ -1,0 +1,3 @@
+const FPS = 30;
+
+export { FPS };

--- a/frontend/src/bundles/studio/components/audio-player/enums/audio-event.ts
+++ b/frontend/src/bundles/studio/components/audio-player/enums/audio-event.ts
@@ -1,0 +1,5 @@
+const AudioEvent = {
+    ENDED: 'ended',
+} as const;
+
+export { AudioEvent };

--- a/frontend/src/bundles/studio/components/audio-player/enums/enums.ts
+++ b/frontend/src/bundles/studio/components/audio-player/enums/enums.ts
@@ -1,0 +1,1 @@
+export { AudioEvent } from './audio-event.js';

--- a/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
@@ -2,19 +2,30 @@ import {
     Editable,
     EditablePreview,
     EditableTextarea,
+    HStack,
     Icon,
     IconButton,
     VStack,
 } from '~/bundles/common/components/components.js';
-import { useAppDispatch, useCallback } from '~/bundles/common/hooks/hooks.js';
+import {
+    useAppDispatch,
+    useCallback,
+    useState,
+} from '~/bundles/common/hooks/hooks.js';
 import { IconName } from '~/bundles/common/icons/icons.js';
+import { AudioPlayer } from '~/bundles/studio/components/audio-player/audio-player.js';
 import { actions as studioActions } from '~/bundles/studio/store/studio.js';
 import { type Script as ScriptT } from '~/bundles/studio/types/types.js';
+
+// TODO: remove mocked url when script audioUrl will be taken from text-to-speech
+const audioUrl = 'https://d2tm5q3cg1nlwf.cloudfront.net/tts_1725818217391.wav';
 
 type Properties = ScriptT;
 
 const Script: React.FC<Properties> = ({ id, text }) => {
     const dispatch = useAppDispatch();
+
+    const [isPlaying, setIsPlaying] = useState(false);
 
     const handleDeleteScript = useCallback((): void => {
         void dispatch(studioActions.deleteScript(id));
@@ -22,21 +33,44 @@ const Script: React.FC<Properties> = ({ id, text }) => {
 
     const handleEditScript = useCallback(
         (newText: string): void => {
+            if (text === newText) {
+                return;
+            }
+
             void dispatch(studioActions.editScript({ id, text: newText }));
         },
-        [dispatch, id],
+        [dispatch, id, text],
     );
+
+    const toggleIsPlaying = useCallback((): void => {
+        setIsPlaying((previous) => !previous);
+    }, []);
+
+    const handleAudioEnd = useCallback(() => {
+        setIsPlaying(false);
+    }, []);
 
     return (
         <VStack w="full">
-            <IconButton
-                icon={<Icon as={IconName.CLOSE} />}
-                size="sm"
-                variant="ghostIconDark"
-                aria-label="Delete script"
-                alignSelf="end"
-                onClick={handleDeleteScript}
-            />
+            <HStack justify="end" w="full" gap={0}>
+                <IconButton
+                    icon={
+                        <Icon as={isPlaying ? IconName.STOP : IconName.PLAY} />
+                    }
+                    size="sm"
+                    variant="ghostIconDark"
+                    aria-label="Play script"
+                    onClick={toggleIsPlaying}
+                    borderRadius="100%"
+                />
+                <IconButton
+                    icon={<Icon as={IconName.CLOSE} />}
+                    size="sm"
+                    variant="ghostIconDark"
+                    aria-label="Delete script"
+                    onClick={handleDeleteScript}
+                />
+            </HStack>
             <Editable
                 defaultValue={text}
                 isPreviewFocusable={true}
@@ -65,6 +99,13 @@ const Script: React.FC<Properties> = ({ id, text }) => {
                     }}
                 />
             </Editable>
+            {audioUrl && (
+                <AudioPlayer
+                    isPlaying={isPlaying}
+                    audioUrl={audioUrl}
+                    handleAudioEnd={handleAudioEnd}
+                />
+            )}
         </VStack>
     );
 };

--- a/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
@@ -6,6 +6,7 @@ import {
     Icon,
     IconButton,
     Spinner,
+    Tooltip,
     VStack,
 } from '~/bundles/common/components/components.js';
 import {
@@ -84,15 +85,22 @@ const Script: React.FC<Properties> = ({ id, text, url }) => {
     return (
         <VStack w="full">
             <HStack justify="end" w="full" gap={0}>
-                <IconButton
-                    icon={<Icon as={iconComponent} />}
-                    size="sm"
-                    variant="ghostIconDark"
-                    aria-label="Play script"
-                    onClick={toggleIsPlaying}
-                    borderRadius="100%"
-                    border={url ? '' : '1px dotted'}
-                />
+                <Tooltip
+                    isDisabled={Boolean(url)}
+                    label="Click to update audio"
+                    placement="top"
+                    hasArrow
+                >
+                    <IconButton
+                        icon={<Icon as={iconComponent} />}
+                        size="sm"
+                        variant="ghostIconDark"
+                        aria-label="Play script"
+                        onClick={toggleIsPlaying}
+                        borderRadius="100%"
+                        border={url ? '' : '1px dotted'}
+                    />
+                </Tooltip>
                 <IconButton
                     icon={<Icon as={IconName.CLOSE} />}
                     size="sm"

--- a/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
@@ -49,6 +49,13 @@ const Script: React.FC<Properties> = ({ id, text, url }) => {
         [dispatch, id, text],
     );
 
+    const handleSetScriptDuration = useCallback(
+        (duration: number): void => {
+            void dispatch(studioActions.editScript({ id, duration }));
+        },
+        [dispatch, id],
+    );
+
     const toggleIsPlaying = useCallback((): void => {
         if (url) {
             setIsPlaying((previous) => !previous);
@@ -142,6 +149,7 @@ const Script: React.FC<Properties> = ({ id, text, url }) => {
                     isPlaying={isPlaying}
                     audioUrl={url}
                     handleAudioEnd={handleAudioEnd}
+                    handleSetDuration={handleSetScriptDuration}
                 />
             )}
         </VStack>

--- a/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu-content/script-content/components/script.tsx
@@ -77,7 +77,6 @@ const Script: React.FC<Properties> = ({ id, text, url }) => {
     useEffect(() => {
         if (url) {
             setIsAudioLoading(false);
-            setIsPlaying(true);
         }
     }, [url]);
 

--- a/frontend/src/bundles/studio/pages/studio.tsx
+++ b/frontend/src/bundles/studio/pages/studio.tsx
@@ -29,7 +29,7 @@ import styles from './styles.module.css';
 
 const initialRange: Range = {
     start: minutesToMilliseconds(0),
-    end: minutesToMilliseconds(2),
+    end: minutesToMilliseconds(1),
 };
 
 const Studio: React.FC = () => {

--- a/frontend/src/bundles/studio/store/slice.ts
+++ b/frontend/src/bundles/studio/store/slice.ts
@@ -92,16 +92,10 @@ const { reducer, actions, name } = createSlice({
                 Required<Pick<Script, 'id'>> & Partial<Script>
             >,
         ) {
-            const { id, ...scriptData } = action.payload;
+            const { id, ...updatedScriptData } = action.payload;
 
             state.scripts = state.scripts.map((script) =>
-                script.id === id
-                    ? {
-                          ...script,
-                          duration: MIN_SCRIPT_DURATION,
-                          ...scriptData,
-                      }
-                    : script,
+                script.id === id ? { ...script, ...updatedScriptData } : script,
             );
         },
         deleteScript(state, action: PayloadAction<string>) {

--- a/frontend/src/bundles/studio/store/slice.ts
+++ b/frontend/src/bundles/studio/store/slice.ts
@@ -86,12 +86,21 @@ const { reducer, actions, name } = createSlice({
 
             state.scripts.push(script);
         },
-        editScript(state, action: PayloadAction<Omit<Script, 'duration'>>) {
-            const { id, text } = action.payload;
+        editScript(
+            state,
+            action: PayloadAction<
+                Required<Pick<Script, 'id'>> & Partial<Script>
+            >,
+        ) {
+            const { id, ...scriptData } = action.payload;
 
             state.scripts = state.scripts.map((script) =>
                 script.id === id
-                    ? { ...script, text, duration: MIN_SCRIPT_DURATION }
+                    ? {
+                          ...script,
+                          duration: MIN_SCRIPT_DURATION,
+                          ...scriptData,
+                      }
                     : script,
             );
         },


### PR DESCRIPTION
Related issue - https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/issues/202

- Each script on video-menu now have a play button. If user clicks on play button the script audio is played. Script audio is mocked for now.
- If user changes the script text, script url is removed and special icon border and tooltip appears. To play the script user must click on play button to load script url (this process is mocked now).
- When script url is loaded, script duration (which is used on the timeline) is updated.

https://www.loom.com/share/31ad776741284c3294bb26433e902bff