### PR TITLE
OV-278: Fix color background sidebar items

### DIFF
--- a/frontend/src/bundles/common/components/sidebar/components/sidebar-item/sidebar-item.tsx
+++ b/frontend/src/bundles/common/components/sidebar/components/sidebar-item/sidebar-item.tsx
@@ -25,7 +25,8 @@ const SidebarItem = ({
         <Box
             as="button"
             className={`${styles['sidebarItem']} ${isCollapsed ? styles['itemJustifyCenter'] : styles['itemJustifyStart']}`}
-            style={{ backgroundColor: bg, color }}
+            bg={bg}
+            color={color}
             onClick={onClick}
         >
             {icon}

--- a/frontend/src/bundles/common/components/sidebar/sidebar.tsx
+++ b/frontend/src/bundles/common/components/sidebar/sidebar.tsx
@@ -118,7 +118,7 @@ const Sidebar = ({ children }: Properties): JSX.Element => {
                         />
                     }
                     isCollapsed={isCollapsed}
-                    label={'log out'}
+                    label={'Log out'}
                     onClick={handleLogOut}
                 />
             </Flex>


### PR DESCRIPTION
Fix background active items and logout color
![image](https://github.com/user-attachments/assets/6524566b-0734-4a1f-bdec-7c779ca518d5)
