### PR TITLE
OV-305: Set total duration by scripts

### DIFF
--- a/frontend/src/bundles/studio/store/selectors.ts
+++ b/frontend/src/bundles/studio/store/selectors.ts
@@ -3,13 +3,13 @@ import { secondsToMilliseconds } from 'date-fns';
 
 import { type RootState } from '~/bundles/common/types/types.js';
 
-import { type Scene } from '../types/types.js';
+import { type Script } from '../types/types.js';
 
-const selectScenes = (state: RootState): Scene[] => state.studio.scenes;
+const selectScrips = (state: RootState): Script[] => state.studio.scripts;
 
-const selectTotalDuration = createSelector([selectScenes], (scenes) => {
-    const totalDuration = scenes.reduce(
-        (total, scene) => total + scene.duration,
+const selectTotalDuration = createSelector([selectScrips], (scripts) => {
+    const totalDuration = scripts.reduce(
+        (total, script) => total + script.duration,
         0,
     );
 


### PR DESCRIPTION
In this pr:

- Determine the end of the video (total duration) by scripts and not by scenes

![image](https://github.com/user-attachments/assets/83ad3ee4-399d-49f8-8e49-547e654ad20a)
