### PR TITLE
OV-294: Add video ending cursor

### DIFF
--- a/frontend/src/bundles/studio/components/timeline/components.ts
+++ b/frontend/src/bundles/studio/components/timeline/components.ts
@@ -3,3 +3,4 @@ export { Row, ScenesRow, ScriptsRow } from './rows/rows.js';
 export { TimeAxis } from './timeaxis/timeaxis.js';
 export { TimeCursor } from './timecursor/timecursor.js';
 export { TimelineView } from './timeline-view/timeline-view.js';
+export { VideoEndingCursor } from './video-ending-cursor/video-ending-cursor.js';

--- a/frontend/src/bundles/studio/components/timeline/timeline-view/timeline-view.tsx
+++ b/frontend/src/bundles/studio/components/timeline/timeline-view/timeline-view.tsx
@@ -11,6 +11,7 @@ import {
     ScriptsRow,
     TimeAxis,
     TimeCursor,
+    VideoEndingCursor
 } from '../components.js';
 
 type Properties = {
@@ -28,6 +29,7 @@ const TimelineView: React.FC<Properties> = ({ playerRef }) => {
             <ScenesRow />
             <ScriptsRow />
             <Row id="emptyBottom" />
+            <VideoEndingCursor />
         </Box>
     );
 };

--- a/frontend/src/bundles/studio/components/timeline/timeline-view/timeline-view.tsx
+++ b/frontend/src/bundles/studio/components/timeline/timeline-view/timeline-view.tsx
@@ -11,7 +11,7 @@ import {
     ScriptsRow,
     TimeAxis,
     TimeCursor,
-    VideoEndingCursor
+    VideoEndingCursor,
 } from '../components.js';
 
 type Properties = {

--- a/frontend/src/bundles/studio/components/timeline/video-ending-cursor/styles.module.css
+++ b/frontend/src/bundles/studio/components/timeline/video-ending-cursor/styles.module.css
@@ -4,3 +4,8 @@
     z-index: 3;
     position: absolute;
 }
+.text {
+    position: absolute;
+    background-color: white;
+    transform: translateX(-50%);
+}

--- a/frontend/src/bundles/studio/components/timeline/video-ending-cursor/styles.module.css
+++ b/frontend/src/bundles/studio/components/timeline/video-ending-cursor/styles.module.css
@@ -1,0 +1,6 @@
+.cursor {
+    height: 100%;
+    width: 2px;
+    z-index: 3;
+    position: absolute;
+}

--- a/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
+++ b/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
@@ -1,0 +1,23 @@
+import { Box } from '~/bundles/common/components/components.js';
+import { useAppSelector } from '~/bundles/common/hooks/hooks.js';
+import { useTimelineContext } from '~/bundles/studio/hooks/hooks.js';
+import { selectTotalDuration } from '~/bundles/studio/store/selectors.js';
+
+import styles from './styles.module.css';
+
+const VideoEndingCursor: React.FC = () => {
+    const totalDuration = useAppSelector(selectTotalDuration);
+    const { valueToPixels } = useTimelineContext();
+
+    const position = valueToPixels(totalDuration);
+
+    return (
+        <Box
+            className={styles['cursor']}
+            backgroundColor="typography.300"
+            style={{ left: `${position}px` }}
+        ></Box>
+    );
+};
+
+export { VideoEndingCursor };

--- a/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
+++ b/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
@@ -18,11 +18,9 @@ const VideoEndingCursor: React.FC = () => {
             style={{ left: `${position}px` }}
         >
             <Text
-                position="absolute"
-                transform="translateX(-50%)"
+                className={styles['text']}
                 color="typography.300"
                 fontSize="sm"
-                backgroundColor="white"
             >
                 End
             </Text>

--- a/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
+++ b/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
@@ -1,4 +1,4 @@
-import { Box } from '~/bundles/common/components/components.js';
+import { Box, Text } from '~/bundles/common/components/components.js';
 import { useAppSelector } from '~/bundles/common/hooks/hooks.js';
 import { useTimelineContext } from '~/bundles/studio/hooks/hooks.js';
 import { selectTotalDuration } from '~/bundles/studio/store/selectors.js';
@@ -16,7 +16,17 @@ const VideoEndingCursor: React.FC = () => {
             className={styles['cursor']}
             backgroundColor="typography.300"
             style={{ left: `${position}px` }}
-        ></Box>
+        >
+            <Text
+                position="absolute"
+                transform="translateX(-50%)"
+                color="typography.300"
+                fontSize="sm"
+                backgroundColor='white'
+            >
+                End
+            </Text>
+        </Box>
     );
 };
 

--- a/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
+++ b/frontend/src/bundles/studio/components/timeline/video-ending-cursor/video-ending-cursor.tsx
@@ -22,7 +22,7 @@ const VideoEndingCursor: React.FC = () => {
                 transform="translateX(-50%)"
                 color="typography.300"
                 fontSize="sm"
-                backgroundColor='white'
+                backgroundColor="white"
             >
                 End
             </Text>

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -30,11 +30,7 @@ const routes = [
             },
             {
                 path: AppRoute.STUDIO,
-                element: (
-                    <ProtectedRoute>
-                        <Studio />
-                    </ProtectedRoute>
-                ),
+                element: <Studio />,
             },
             {
                 path: AppRoute.MY_AVATAR,

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -30,7 +30,11 @@ const routes = [
             },
             {
                 path: AppRoute.STUDIO,
-                element: <Studio />,
+                element: (
+                    <ProtectedRoute>
+                        <Studio />
+                    </ProtectedRoute>
+                ),
             },
             {
                 path: AppRoute.MY_AVATAR,


### PR DESCRIPTION
At the moment the cursor is placed at the end of last scene, but once https://github.com/BinaryStudioAcademy/bsa-2024-outreachvids/pull/306#pullrequestreview-2306328146 is merged it will be placed at the end of last script.
![Screenshot 2024-09-16 071431](https://github.com/user-attachments/assets/b307d1b6-bac5-490c-a914-b67738f67556)


