### PR TITLE
OV-314: Change menu body height and position so it does not cover the timeline

### DIFF
--- a/frontend/src/bundles/studio/components/video-menu/components/menu-body/styles.module.css
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu-body/styles.module.css
@@ -3,7 +3,7 @@
     top: 40%;
     transform: translateY(-50%);
     left: 100px;
-    height: 60vh;
+    height: 55vh;
     width: 335px;
     padding: 12px 18px 0 18px;
     z-index: 1000;

--- a/frontend/src/bundles/studio/components/video-menu/components/menu-body/styles.module.css
+++ b/frontend/src/bundles/studio/components/video-menu/components/menu-body/styles.module.css
@@ -1,9 +1,9 @@
 .menu-body {
     position: fixed;
-    top: 50%;
+    top: 40%;
     transform: translateY(-50%);
     left: 100px;
-    height: 72vh;
+    height: 60vh;
     width: 335px;
     padding: 12px 18px 0 18px;
     z-index: 1000;


### PR DESCRIPTION
Decreased the menu body height and moved it up so it doesn't cover the timeline component.
![image](https://github.com/user-attachments/assets/0d74717d-4969-4444-9bfd-8a1bd0923694)
