### PR TITLE
OV-181: Add new migrations to update email field max length to 320

### DIFF
--- a/backend/src/migrations/20240815120000_update_email_length.ts
+++ b/backend/src/migrations/20240815120000_update_email_length.ts
@@ -2,10 +2,11 @@ import { type Knex } from 'knex';
 
 const TABLE_NAME = 'users';
 const COLUMN_NAME = 'email';
+const MAX_EMAIL_LENGTH = 320;
 
 async function up(knex: Knex): Promise<void> {
     await knex.schema.alterTable(TABLE_NAME, (table) => {
-        table.string(COLUMN_NAME, 320).alter();
+        table.string(COLUMN_NAME, MAX_EMAIL_LENGTH).alter();
     });
 }
 

--- a/backend/src/migrations/20240815120000_update_email_length.ts
+++ b/backend/src/migrations/20240815120000_update_email_length.ts
@@ -1,0 +1,18 @@
+import { type Knex } from 'knex';
+
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'email';
+
+async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.string(COLUMN_NAME, 320).alter();
+    });
+}
+
+async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.string(COLUMN_NAME).alter();
+    });
+}
+
+export { down, up };


### PR DESCRIPTION
Summary
This PR creates a new migration file to update the maximum length of the email field in the USERS table. This change addresses the error that occurs when a new user registers with an email length between 255 and 320 characters.

Details

- Migration: Adds a new migration to alter the email column length to 320 characters.
- Issue: Fixes the error encountered during user registration with long email addresses.

Changes

- Created a new migration file 20240815120000_update_email_length.ts.
- Updated the email column in the USERS table to have a maximum length of 320 characters.

Please remember to reapply migrations when testing and after merge

https://github.com/user-attachments/assets/294a0eea-c985-41bb-bead-531ae8bbb525

Used email with 315 chars: yourname_unique_id_1234_abcdefghij_klmnop111qrstuvwxyz_001234567890_thelonganddetailednameforyourservicea123aazccasdsasdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.com