### PR TITLE
OV-327: Fix sidebar expand button

### DIFF
--- a/frontend/src/bundles/common/components/logo/logo.tsx
+++ b/frontend/src/bundles/common/components/logo/logo.tsx
@@ -23,7 +23,12 @@ const Logo: React.FC<Properties> = ({
         >
             <Icon as={IconName.LOGO} boxSize={logoSize} {...rest} />
             {textSize && (
-                <Icon as={IconName.LOGO_TEXT} boxSize={textSize} ml={2} />
+                <Icon
+                    as={IconName.LOGO_TEXT}
+                    boxSize={textSize}
+                    ml={2}
+                    h="auto"
+                />
             )}
         </Box>
     );


### PR DESCRIPTION
Icon was too tall, positioning over the expand button, I resize its height value.