### PR TITLE
OV-350: Add draft tag

### DIFF
--- a/frontend/src/bundles/home/components/video-card/styles.module.css
+++ b/frontend/src/bundles/home/components/video-card/styles.module.css
@@ -26,3 +26,11 @@
     opacity: 0;
     transition: opacity 0.3s ease;
 }
+
+.draft-box {
+    position: absolute;
+    bottom: 1vh;
+    left: 1vh;
+    border-radius: 4px;
+    padding: 2px 8px;
+}

--- a/frontend/src/bundles/home/components/video-card/video-card.tsx
+++ b/frontend/src/bundles/home/components/video-card/video-card.tsx
@@ -64,7 +64,14 @@ const VideoCard: React.FC<Properties> = ({ id, name, url }) => {
         <Box borderRadius="8px" bg="white" padding="7px">
             <Box position="relative" role="group">
                 <Image src={photo} alt="Video preview" borderRadius="5px" />
-
+                {!url && (
+                    <Box
+                        className={styles['draft-box']}
+                        backgroundColor="background.300"
+                    >
+                        <Text variant="bodySmall">Draft</Text>
+                    </Box>
+                )}
                 <Box
                     _groupHover={{ opacity: 1 }}
                     className={styles['overlay']}


### PR DESCRIPTION
Summary:
Added a "Draft" tag in the bottom-left corner of video cards that do not have a URL.

Details:
The "Draft" tag is displayed as a light blue box with rounded corners and the word 'Draft' inside.

https://github.com/user-attachments/assets/b7f0dea0-176a-435b-bd8e-ceacc0d09d15

