### PR TITLE
OV-407:  Limit the video title to one line

### DIFF
--- a/frontend/src/bundles/home/components/video-card/styles.module.css
+++ b/frontend/src/bundles/home/components/video-card/styles.module.css
@@ -42,3 +42,9 @@
     border-radius: 4px;
     padding: 2px 8px;
 }
+
+.card-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/frontend/src/bundles/home/components/video-card/video-card.tsx
+++ b/frontend/src/bundles/home/components/video-card/video-card.tsx
@@ -182,7 +182,11 @@ const VideoCard: React.FC<Properties> = ({
             </Box>
 
             <Box padding="7px 10px 5px 5px">
-                <Text variant="button" color="typography.900">
+                <Text
+                    variant="button"
+                    color="typography.900"
+                    className={styles['card-title']}
+                >
                     {name}
                 </Text>
                 <Flex justify="space-between">


### PR DESCRIPTION
The video title is limited to one line; if it exceeds the size, three dots are displayed.