### PR TITLE
OV-424: Error when selecting background before avatar

### DIFF
--- a/frontend/src/bundles/studio/components/video/styles.module.css
+++ b/frontend/src/bundles/studio/components/video/styles.module.css
@@ -4,14 +4,23 @@
     justify-content: center;
 }
 
-.background {
-    background-size: cover;
+.image {
+    position: absolute;
+    object-fit: cover;
+    z-index: 2;
     height: 100%;
     width: 100%;
-    justify-content: center;
 }
 
-.image {
+.background {
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    position: absolute;
+}
+
+.avatar {
+    z-index: 3;
     position: absolute;
     object-fit: contain;
     bottom: 0;

--- a/frontend/src/bundles/studio/components/video/video.tsx
+++ b/frontend/src/bundles/studio/components/video/video.tsx
@@ -1,7 +1,6 @@
 import {
     AbsoluteFill,
     Audio,
-    Flex,
     RemotionImg,
     Series,
 } from '~/bundles/common/components/components.js';
@@ -38,18 +37,27 @@ const VideoComponent: React.FC<Properties> = ({ scenes, scripts }) => {
                             durationInFrames={scene.duration * FPS}
                             className={styles['sequence'] as string}
                         >
-                            {scene?.avatar?.url || scene.background ? (
-                                <Flex
-                                    background={`${scene.background?.color ?? ''} url(${scene.background?.url ?? ''}) no-repeat`}
-                                    className={styles['background']}
-                                >
-                                    <RemotionImg
-                                        className={styles['image']}
-                                        src={scene?.avatar?.url ?? ''}
-                                    />
-                                </Flex>
+                            {scene?.avatar?.url ? (
+                                <RemotionImg
+                                    className={styles['avatar']}
+                                    src={scene?.avatar?.url ?? ''}
+                                />
                             ) : (
                                 <></>
+                            )}
+                            {scene?.background?.url && (
+                                <RemotionImg
+                                    className={styles['image']}
+                                    src={scene?.background?.url}
+                                />
+                            )}
+                            {scene?.background?.color && (
+                                <div
+                                    style={{
+                                        backgroundColor: `${scene?.background?.color}`,
+                                    }}
+                                    className={styles['background']}
+                                ></div>
                             )}
                         </Series.Sequence>
                     );


### PR DESCRIPTION
The bug is fixed. User can add background before the avatar to the scene and vice versa